### PR TITLE
Fix build_image.sh

### DIFF
--- a/build_images.sh
+++ b/build_images.sh
@@ -23,7 +23,7 @@ while read DIRECTORY; do
   if [[ "${PUSH_IMAGES:-}" == 'true' ]]; then
     IMAGES_TO_PUSH+=("${IMAGE_NAME}":"${IMAGE_TAG}")
   fi
-done < <(find docker/ -maxdepth 1 -type d -name '*-*-*')
+done < <(find docker/ -maxdepth 1 -type d -name '*-mongo_*')
 
 # If there are images to push, do so
 for IMAGE_TO_PUSH in "${IMAGES_TO_PUSH[@]}"; do

--- a/update.sh
+++ b/update.sh
@@ -16,7 +16,7 @@ BUILD_VERSION=$(<VERSION)
 
 for MONGO_VERSION in "${IMAGE_VERSIONS}"; do
   echo "# Processing - Mongo: ${MONGO_VERSION}"
-  IMAGE_TAG="${BUILD_VERSION}-${MONGO_VERSION}"
+  IMAGE_TAG="${BUILD_VERSION}-mongo_${MONGO_VERSION}"
 
   # Create directory if it doesn't exist yet
   if [[ ! -d "${IMAGE_TAG}" ]]; then


### PR DESCRIPTION
The docker image directory match in `build_images.sh` was failing for release builds. Fixed and improved the directory match and added `mongo_` to the version number to make clear the second part is the mongo version.